### PR TITLE
Add contact page with embedded inquiry form

### DIFF
--- a/src/components/HeaderComponent.vue
+++ b/src/components/HeaderComponent.vue
@@ -69,6 +69,11 @@
             >
           </li>
           <li class="nav-item">
+            <router-link class="nav-link" aria-current="page" to="/contact"
+              >Contact</router-link
+            >
+          </li>
+          <li class="nav-item">
             <router-link class="nav-link" aria-current="page" to="/blog"
               >Blog</router-link
             >

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import InfoView from '../views/InfoView.vue'
+import ContactView from '../views/ContactView.vue'
 // import BlogView from '../views/BlogView.vue'
 
 const routes = [
@@ -28,6 +29,11 @@ const routes = [
     path: '/info',
     name: 'info',
     component: InfoView
+  },
+  {
+    path: '/contact',
+    name: 'contact',
+    component: ContactView
   },
   {
     path: '/blog',

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -1,0 +1,38 @@
+<template>
+  <section class="contact-page container py-5">
+    <h1 class="text-center mb-4">お問い合わせ</h1>
+    <p class="lead text-center mb-5">
+      ご依頼やご相談は、以下のフォームよりお気軽にご連絡ください。
+    </p>
+    <div class="form-wrapper mx-auto">
+      <iframe
+        title="Contact form"
+        src="https://docs.google.com/forms/d/e/1FAIpQLScZfrPBOn0vPa0oQUvWqy36jqIojeTf7IWhSQQnrksPn8lEjw/viewform?embedded=true"
+        width="640"
+        height="974"
+        frameborder="0"
+        marginheight="0"
+        marginwidth="0"
+      >
+        読み込んでいます…
+      </iframe>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: "ContactView",
+};
+</script>
+
+<style scoped>
+.form-wrapper {
+  max-width: 720px;
+}
+
+iframe {
+  width: 100%;
+  border: none;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a dedicated Contact view that embeds the provided Google Form and styles it responsively
- register the new route and expose it through the site navigation

## Testing
- yarn serve

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd4bbda68832cb3646cb08cc8cc7f)